### PR TITLE
Prevent collinear error if only 1 variable for vif_select

### DIFF
--- a/R/collinear.R
+++ b/R/collinear.R
@@ -196,13 +196,15 @@ collinear <- function(
   )
 
   #applying vif selection
-  selected.predictors <- vif_select(
-    df = df,
-    response = response,
-    predictors = selected.predictors,
-    preference_order = preference_order,
-    max_vif = max_vif
+  if(length(selected.predictors) > 1) {
+      selected.predictors <- vif_select(
+        df = df,
+        response = response,
+        predictors = selected.predictors,
+        preference_order = preference_order,
+        max_vif = max_vif
   )
+  }
 
   selected.predictors
 


### PR DESCRIPTION
`colinear()` fails with an error if only one variable is selected by `cor_select()` and is passed to vif_select(). So, I added `if(length(selected.predictors) > 1)` before `selected.predictors <- vif_select(...`

Let me know if you want an example dataset to test this.