### PR TITLE
Prevent vif_select() error when only 1 variable

### DIFF
--- a/R/vif_select.R
+++ b/R/vif_select.R
@@ -244,7 +244,8 @@ vif_select <- function(
   )
 
   #iterating through reversed preference order
-  for(i in seq(from = nrow(df.rank), to = 2)){
+  if(nrow(df.rank) > 1) {
+      for(i in seq(from = nrow(df.rank), to = 2)){
 
     vif.i <- vif_df(
       df = df,
@@ -266,7 +267,10 @@ vif_select <- function(
 
     }
 
-  }
+          }
+  } else {
+      warning("Only one variable provided; no way to select.")
+      }
 
   #selected variables
   df.rank$variable


### PR DESCRIPTION
Added `if(nrow(df.rank) > 1)` before the loop `for(i in seq(from = nrow(df.rank), to = 2))`, to prevent error if a user workflow attempts `vif_select()` with only one variable. Included a warning instead - please edit to your own style.

Let me know if you'd like my example dataset to test this.