### PR TITLE
Remove non-varying predictors to prevent cor_select() error

### DIFF
--- a/R/cor_select.R
+++ b/R/cor_select.R
@@ -135,6 +135,14 @@ cor_select <- function(
     stop("argument 'max_cor' must be a numeric between 0 and 1.")
   }
 
+  #remove constants, to prevent NA correlations and downstream errors:
+  constants <- which(sapply(df[ , predictors], function(x) length(unique(x)) == 1))
+  if (length(constants) > 0) {
+    message("predictor(s) excluded for having no variation:\n", 
+            paste(predictors[constants], collapse = "; "))
+    predictors <- predictors[-constants]
+  }
+
   #correlation data frame
   cor.df <- cor_df(
     df = df,


### PR DESCRIPTION
Otherwise, if a predictor has no variation in the dataset passed to cor_select(), NA correlation coefficients cause some mysterious error messages:

```
data(vi, vi_predictors)
vi <- vi[1:100, ]
vi_predictors <- vi_predictors[1:10]
vi$constant <- rep("constant", nrow(vi))
vi_predictors <- c(vi_predictors, "constant")

cor_select(df = vi, predictors = vi_predictors)
```