### PR TITLE
Pass only relevant columns to validate_df()

### DIFF
--- a/R/collinear.R
+++ b/R/collinear.R
@@ -184,7 +184,7 @@ collinear <- function(
 
   #validate df
   df <- validate_df(
-    df = df,
+    df = df[ , c(response, predictors)],
     quiet = quiet
   )
 


### PR DESCRIPTION
...as it is puzzling to the users (and probably wastes computational resources) when `collinear()` produces console messages about columns that are not supposed to be under analysis.

If you agree, the same should probably be done for other functions that use `validate_df()` too.

Example:
```
df <- vi[1:500, ]

# introduce an extra column:
test_sample <- sample(1:nrow(df), 100, replace = FALSE)
df$test <- FALSE
df$test[test_sample] <- TRUE

collinear(df = df, response = "vi_numeric", predictors = c("swi_mean", "soil_temperature_mean", "growing_season_length"))

# collinear::validate_df(): converting these logical column/s to numeric: 
# - test
# [...]
```