### PR TITLE
Fix URLs to blog posts on the pkgdown website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -41,11 +41,11 @@ navbar:
       text: Blog Posts
       menu:
       - text: "Multicollinearity Hinders Model Interpretability"
-        href: https://www.blasbenito.com/post/multicollinearity-model-interpretability/
+        href: https://www.blasbenito.com/2023/10/29/multicollinearity-model-interpretability/
       - text: "Everything About Variance Inflation Factors"
-        href: https://www.blasbenito.com/post/variance-inflation-factor/
+        href: https://www.blasbenito.com/2023/11/05/variance-inflation-factor/
       - text: "Mapping Categorical Predictors to Numeric"
-        href: https://www.blasbenito.com/post/target-encoding/
+        href: https://www.blasbenito.com/2023/11/15/target-encoding/
   structure:
     left: [intro, reference, articles, blog, news]
     right: [search, github]


### PR DESCRIPTION
Hello!
First of all, thanks for the great package and extensive documentation to it!

On the pkgdown website, I've noticed that links to blog posts are currently broken.
This PR fixes the URLs.

With kind regards,
Vladimir